### PR TITLE
add client mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ stunnel_services: list of services. They look like this:
     name: https
     accept: 443
     connect: 80
-  
+    client: "yes"  # defaults to "no"
 ```
+
+(beware, set client to string "yes", not to yes alone, which, in yaml, is boolean value true)
 
 Dependencies
 ------------

--- a/templates/stunnel.conf.j2
+++ b/templates/stunnel.conf.j2
@@ -4,6 +4,7 @@ output=/var/log/stunnel.log
 
 {% for service in stunnel_services %}
 [{{service.name}}]
+  client = {{ service.client|default("no") }}
   accept = {{service.accept}}
   connect= {{service.connect}}
 {% endfor %}


### PR DESCRIPTION
Add "client" mode parameter to services.

This is needed when you hide a service behind stunnel on a server, and talk to it through another instance of stunnel on the client.