### PR TITLE
Drop privilege role

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ Role Variables
     1. `use_psk` (optional, defaults to global `stunnel_use_psk`) : determines PSK usage for this specific service
     1. `PSKidentity` (optional, depends on `use_psk`) : determines PSK identity for this specific service. This identity should be configured in `PSKsecrets`
 
+1. `stunnel_uid` (default `stunnel4`): name of the user to use for the service.
+   If empty stunnel will keep parent uid.
+   (stunnel strongly recommends to drop privileges).
+1. `stunnel_gid` (default `stunnel4`): name of the group to use for the service.
+   If empty stunnel will keep parent gid.
+1. `stunnel_pid` (default `/var/run/stunnel4/stunnel.pid`): path to the file where pid will be stored.
+   If the argument is empty, then no pid file will be created.
+1. `stunnel_output` (default `/var/log/stunnel4/stunnel.log`): append log messages to a file
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,5 +13,7 @@ stunnel_certificate_file: /tmp/certificate.pem
 stunnel_key_file: /tmp/key.pem
 stunnel_services: []
 stunnel_psks: []
-stunnel_pid: /var/run/stunnel.pid
-stunnel_output: /var/log/stunnel.log
+stunnel_uid: stunnel4
+stunnel_gid: stunnel4
+stunnel_pid: /var/run/stunnel4/stunnel.pid
+stunnel_output: /var/log/stunnel4/stunnel.log

--- a/templates/stunnel.conf.j2
+++ b/templates/stunnel.conf.j2
@@ -1,3 +1,5 @@
+setuid = {{ stunnel_uid }}
+setgid = {{ stunnel_gid }}
 pid = {{ stunnel_pid }}
 output = {{ stunnel_output }}
 

--- a/templates/stunnel.conf.j2
+++ b/templates/stunnel.conf.j2
@@ -1,5 +1,10 @@
+{% if stunnel_uid %}
 setuid = {{ stunnel_uid }}
+{% endif %}
+{% if stunnel_gid %}
 setgid = {{ stunnel_gid }}
+{% endif %}
+
 pid = {{ stunnel_pid }}
 output = {{ stunnel_output }}
 


### PR DESCRIPTION
On debian / ubuntu, as stated in the stunnel documentation, stunnel drops root priviledges and use a normal user.

If you prefer, I can rewrite it to have it done optionally.