### PR TITLE
Added multiple options for config file: pid, output, PSKIdentity, client

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Role Variables
 --------------
 
 1. `stunnel_install_ssl_backend` (optional, default False) : determines if we want to install openssl by this role
-1. `stunnel_use_cert` (default True) : determines if we use certificates
+1. `stunnel_use_certificate` (default True) : determines if we use certificates
 1. `stunnel_use_psk` (default False) : determines if we use psk
 1. `stunnel_certificate_generation` (default False) : determines if this role has to generate a self signed certificate
 1. `stunnel_certificate_duration` (optional, if `stunnel_certificate_generation` is True, default 365) : self signed certificate validity duration

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Install it with `ansible-galaxy install migibert.stunnel`
 Role Variables
 --------------
 
+1. `stunnel_install_ssl_backend` (optional, default False) : determines if we want to install openssl by this role
 1. `stunnel_use_cert` (default True) : determines if we use certificates
 1. `stunnel_use_psk` (default False) : determines if we use psk
 1. `stunnel_certificate_generation` (default False) : determines if this role has to generate a self signed certificate

--- a/README.md
+++ b/README.md
@@ -12,29 +12,35 @@ Install it with `ansible-galaxy install migibert.stunnel`
 Role Variables
 --------------
 
-```
-stunnel_use_cert (default True) : determines if we use certificates
-stunnel_use_psk (default False) : determines if we use psk
-stunnel_certificate_generation (default False) : determines if this role has to generate a self signed certificate
-stunnel_certificate_duration: (optional, if stunnel_certificate_generation is True, default 365) : self signed certificate validity duration
-stunnel_certificate_domain: (optional, if stunnel_certificate_generation is True, default www.domain.com) : self signed certificate domain field
-stunnel_certificate_country: (optional, if stunnel_certificate_generation is True, default FR) : self signed certificate country field
-stunnel_certificate_organization: (optional, if stunnel_certificate_generation is True, default organization) : self signed certificate organization field
-stunnel_certificate_state_name: (optional, if stunnel_certificate_generation is True, default state) : self signed certificate state field
-stunnel_certificate_locality: (optional, if stunnel_certificate_generation is True, default locality) : self signed certificate locality field
-stunnel_certificate_file: certificate file to generate or use, depends on stunnel_certificate_generation value. Default is /tmp/certificate.pem
-stunnel_key_file: key file to generate or use, depends on stunnel_certificate_generation value. Default is /tmp/key.pem
-stunnel_psks: a list of psk. This look like this:
-- name: client1
-  psk: AEO/WE+pBCn3+WBy3FJoyJF/HEBZqMym
+1. `stunnel_use_cert` (default True) : determines if we use certificates
+1. `stunnel_use_psk` (default False) : determines if we use psk
+1. `stunnel_certificate_generation` (default False) : determines if this role has to generate a self signed certificate
+1. `stunnel_certificate_duration` (optional, if `stunnel_certificate_generation` is True, default 365) : self signed certificate validity duration
+1. `stunnel_certificate_domain` (optional, if `stunnel_certificate_generation` is True, default www.domain.com) : self signed certificate domain field
+1. `stunnel_certificate_country` (optional, if `stunnel_certificate_generation` is True, default FR) : self signed certificate country field
+1. `stunnel_certificate_organization` (optional, if `stunnel_certificate_generation` is True, default organization) : self signed certificate organization field
+1. `stunnel_certificate_state_name` (optional, if `stunnel_certificate_generation` is True, default state) : self signed certificate state field
+1. `stunnel_certificate_locality` (optional, if `stunnel_certificate_generation` is True, default locality) : self signed certificate locality field
+1. `stunnel_certificate_file` certificate file to generate or use, depends on `stunnel_certificate_generation` value. Default is /tmp/certificate.pem
+1. `stunnel_key_file` key file to generate or use, depends on `stunnel_certificate_generation` value. Default is /tmp/key.pem
+1. `stunnel_psks` a list of psk. This look like this:
 
-stunnel_services: list of services. They look like this:
-- service:
-  name: https
-  accept: 443
-  connect: 80
+        - name: client1
+          psk: AEO/WE+pBCn3+WBy3FJoyJF/HEBZqMym
 
-```
+1. `stunnel_services`: list of services.
+    They look like this:
+
+        - name: https
+          accept: 443
+          connect: 80
+
+    Each service accepts parameters:
+    1. `accept` (required) : determines address:port to listen
+    1. `connect` (required) : determines address:port to connect
+    1. `client` (optional, default `False`) : determines client-mode
+    1. `use_psk` (optional, defaults to global `stunnel_use_psk`) : determines PSK usage for this specific service
+    1. `PSKidentity` (optional, depends on `use_psk`) : determines PSK identity for this specific service. This identity should be configured in `PSKsecrets`
 
 Dependencies
 ------------
@@ -44,7 +50,7 @@ This role has no dependencies.
 Example Playbook
 ----------------
 
-```
+```yaml
 - hosts: all
 
   roles:
@@ -59,8 +65,7 @@ Example Playbook
     stunnel_certificate_file: /tmp/stunnel.pem
     stunnel_key_file: /tmp/key.pem
     stunnel_services:
-      - service:
-        name: https
+      - name: https
         accept: 443
         connect: 80
 ```
@@ -69,7 +74,7 @@ you may also use [PSK (Pre Shared Keys)](https://www.stunnel.org/auth.html)
 which allow faster communication
 at the cost of knowing clients in advance.
 
-```
+```yaml
 - hosts: all
 
   roles:
@@ -82,10 +87,15 @@ at the cost of knowing clients in advance.
       - name: client2
         key: enNezGQMkZmSyjTDjpndjrBEXhJ9ki3v
     stunnel_services:
-      - service:
-        name: postfix
+      - name: postfix
         accept: 12221
         connect: 21
+      - name: mysql
+        accept: 3307
+        connect: 3306
+        use_psk: yes
+        client: yes
+        PSKidentity: client2
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,5 @@ stunnel_certificate_file: /tmp/certificate.pem
 stunnel_key_file: /tmp/key.pem
 stunnel_services: []
 stunnel_psks: []
+stunnel_pid: /var/run/stunnel.pid
+stunnel_output: /var/log/stunnel.log

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+stunnel_install_ssl_backend: false
 stunnel_use_certificate: true
 stunnel_use_psk: false
 stunnel_certificate_generation: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
     name: openssl
     update_cache: yes
   register: install_ssl_backend
+  when: stunnel_install_ssl_backend
 
 - name: Install package
   package:

--- a/templates/stunnel.conf.j2
+++ b/templates/stunnel.conf.j2
@@ -1,9 +1,9 @@
-pid = /var/run/stunnel.pid
-output = /var/log/stunnel.log
+pid = {{ stunnel_pid }}
+output = {{ stunnel_output }}
 
 {% if stunnel_use_certificate %}
 cert = /etc/stunnel/stunnel.pem
-{% endif %}
+{% endif -%}
 
 {% for service in stunnel_services %}
 [{{service.name}}]
@@ -19,5 +19,4 @@ cert = /etc/stunnel/stunnel.pem
   ciphers = PSK
   PSKsecrets = /etc/stunnel/psk.txt
 {% endif %}
-
 {% endfor %}

--- a/templates/stunnel.conf.j2
+++ b/templates/stunnel.conf.j2
@@ -1,15 +1,21 @@
-pid=/var/run/stunnel.pid
+pid = /var/run/stunnel.pid
 output = /var/log/stunnel.log
 
 {% if stunnel_use_certificate %}
-cert=/etc/stunnel/stunnel.pem
+cert = /etc/stunnel/stunnel.pem
 {% endif %}
 
 {% for service in stunnel_services %}
 [{{service.name}}]
-  accept = {{service.accept}}
-  connect = {{service.connect}}
-{% if stunnel_use_psk %}
+{% if service.client | default(false) %}
+  client = yes
+{% endif %}
+{% if ( stunnel_use_psk or service.use_psk ) and service.PSKidentity | default(false) %}
+  PSKidentity = {{ service.PSKidentity }}
+{% endif %}
+  accept = {{ service.accept }}
+  connect = {{ service.connect }}
+{% if stunnel_use_psk or service.use_psk %}
   ciphers = PSK
   PSKsecrets = /etc/stunnel/psk.txt
 {% endif %}


### PR DESCRIPTION
1. Added global configuration options for `stunnel_pid`, `stunnel_output`;
1. Added service-specific options `PSKidentity`, `client`;
1. Reformatted config file a bit: added spaces around `=` everywhere for consistency.
1. Updated `README.md` with new options and examples


Supersedes #2 